### PR TITLE
fix: 🐛 fix compiled results with `staticRenderFns` in some case

### DIFF
--- a/packages/varlet-vue2-cli/src/compiler/compileSFC.ts
+++ b/packages/varlet-vue2-cli/src/compiler/compileSFC.ts
@@ -15,6 +15,7 @@ export function injectRender(script: string, render: string): string {
       DEFINE_EXPORT_START_RE,
       `${render}\nexport default defineComponent({
   render,\
+  staticRenderFns,\
     `
     )
   }
@@ -24,6 +25,7 @@ export function injectRender(script: string, render: string): string {
       EXPORT_START_RE,
       `${render}\nexport default {
   render,\
+  staticRenderFns,\
     `
     )
   }


### PR DESCRIPTION
## Checklist
我使用varlet作为组件库的架子搭建自己的组件库，在某些极端的场景下，编译结果可能会有部分来自于`staticRenderFns`，而varlet编译的产物没有处理`staticRenderFns`，导致template中编写的源码丢失：

示例组件：
```vue
<template>
  <div class="ali-verification-wrap">
    <div id="captcha-element"></div>
    <div id="captcha-button"></div>
  </div>
</template>

<script>
import { defineComponent } from '../utils/create'
import { props } from './props'

export default defineComponent({
  name: 'AliVerification',
  props,
})
</script>

<style lang="scss">
#aliyunCaptcha-title {
  font-size: 0.45rem !important;
}
</style>
```

编译结果：
```js
//
//
//
//
//
//
//

import { defineComponent } from '../utils/create';
import { props } from './props';
var render = function () {
  var _vm = this;
  var _h = _vm.$createElement;
  var _c = _vm._self._c || _h;
  return _vm._m(0);
};
var staticRenderFns = [function () {
  var _vm = this;
  var _h = _vm.$createElement;
  var _c = _vm._self._c || _h;
  return _c('div', {
    staticClass: "ali-verification-wrap"
  }, [_c('div', {
    attrs: {
      "id": "captcha-element"
    }
  }), _vm._v(" "), _c('div', {
    attrs: {
      "id": "captcha-button"
    }
  })]);
}];
export default defineComponent({
  render,
  name: 'AliVerification',
  props
});
```

## Change information

补充组件`staticRenderFns`选项
